### PR TITLE
Path Specification Fixed

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ import logging
 from colorama import Fore, Style, init
 
 def load_config():
-    config_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'config', 'config.yaml')
+    config_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Config', 'config.yaml')
     with open(config_path, 'r') as config_file:
         return yaml.safe_load(config_file)
 


### PR DESCRIPTION
Program throws error on Linux because of case-sensitive path specification. Line 8 changed to:
config_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Config', 'config.yaml')