### PR TITLE
fix font

### DIFF
--- a/app/templates/holygrail.html
+++ b/app/templates/holygrail.html
@@ -31,7 +31,6 @@
   body {
     background: linear-gradient(135deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
     min-height: 100vh;
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
     color: var(--text-primary);
     overflow-x: hidden;
   }


### PR DESCRIPTION
<img width="536" height="412" alt="image" src="https://github.com/user-attachments/assets/3566cf8d-f1d7-42a6-b99c-e862e236c475" />
this font style was only displayed on holy grails tab, otherwise it looked like
<img width="488" height="442" alt="image" src="https://github.com/user-attachments/assets/25ab272d-75eb-479a-941b-fdf7321ea5cd" />
this PR makes it look like the latter consistently :3 